### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicola-morganti/nextjs-base/security/code-scanning/2](https://github.com/nicola-morganti/nextjs-base/security/code-scanning/2)

To fix the issue, add a `permissions` key at the root of the workflow file. This will explicitly define the permissions granted to the `GITHUB_TOKEN` for the entire workflow. Based on the provided workflow, the minimal set of permissions required appears to be `contents: read`, as the workflow primarily performs actions such as checking out the repository, setting up Node.js, installing dependencies, and running tests. None of these steps appear to require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
